### PR TITLE
[EIC-997]: display collection title instead of name

### DIFF
--- a/src/components/insights/Insights.js
+++ b/src/components/insights/Insights.js
@@ -52,13 +52,13 @@ export default function Insights({ collectionsData }) {
 
     useEffect(() => {
         if (query?.collections) {
-            setCurrentCollection(collections.find((collection) => collection.name === query.collections[0]))
+            setCurrentCollection(collectionsData.find((collection) => collection.name === query.collections[0]))
         } else {
             search({ collections: [collectionsState[0].name] })
         }
     }, [query?.collections])
 
-    const [currentCollection, setCurrentCollection] = useState(collections[0])
+    const [currentCollection, setCurrentCollection] = useState(collectionsData[0])
     const handleMenuClick = (collection) => () => {
         search({ collections: [collection.name] })
     }
@@ -70,7 +70,7 @@ export default function Insights({ collectionsData }) {
                     {collectionsState.map((collection) => (
                         <InsightsTitle
                             key={collection.name}
-                            name={collection.name}
+                            name={collection.title}
                             open={currentCollection?.name === collection.name}
                             onClick={handleMenuClick(collection)}
                         />

--- a/src/components/search/filters/CollectionsFilter/CollectionsFilter.tsx
+++ b/src/components/search/filters/CollectionsFilter/CollectionsFilter.tsx
@@ -39,12 +39,12 @@ export const CollectionsFilter: FC = observer(() => {
                                 <ListItemText
                                     primary={
                                         !categoryQuickFilter.collections?.length ? (
-                                            collection.name
+                                            collection.title
                                         ) : (
                                             <Highlighter
                                                 searchWords={[categoryQuickFilter.collections || '']}
                                                 autoEscape={true}
-                                                textToHighlight={collection.name}
+                                                textToHighlight={collection.title}
                                             />
                                         )
                                     }


### PR DESCRIPTION
There were only 3 UI occurrences of `collection.name`. 

`CollectionsFilter` was used for both search and batch search.

I've also fixed an exception where `collections` was undefined. Switched to `collectionsData` which comes from props.
