### PR TITLE
[EIC-995]: fixed finder flickering issue by persisting sharedStore instance

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { CssBaseline } from '@mui/material'
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon'
 import App, { AppContext, AppProps } from 'next/app'
+import { useMemo } from 'react'
 
 import { whoami } from '../src/backend/api'
 import getAuthorizationHeaders from '../src/backend/getAuthorizationHeaders'
@@ -13,16 +14,18 @@ import { SharedStoreProvider } from '../src/components/SharedStoreProvider'
 import { SharedStore } from '../src/stores/SharedStore'
 import { User } from '../src/Types'
 
-interface HooverApp extends AppProps {
+interface HooverAppProps extends AppProps {
     user: User
 }
 
-export default function HooverApp({ Component, pageProps, user }: HooverApp) {
+export default function HooverApp({ Component, pageProps, user }: HooverAppProps) {
+    const sharedStore = useMemo(() => new SharedStore(user), [user])
+    
     return (
         <CacheProvider value={createCache({ key: 'css', prepend: true })}>
             <LocalizationProvider dateAdapter={AdapterLuxon}>
                 <CssBaseline />
-                <SharedStoreProvider store={new SharedStore(user)}>
+                <SharedStoreProvider store={sharedStore}>
                     <Layout>
                         <Component {...pageProps} />
                     </Layout>

--- a/src/components/document/SubTabs/components/Files/Files.tsx
+++ b/src/components/document/SubTabs/components/Files/Files.tsx
@@ -34,7 +34,10 @@ export const Files = observer(() => {
     }
 
     useEffect(() => {
-        setFiles(data?.children)
+        if (!data) return;
+        setFiles(data.children)
+        setCurrentPage(data.children_page)
+        setCurrentHasNextPage(data.children_has_next_page)
     }, [data])
 
     const filesRows = files?.map(({ id, digest, file, filename, content_type, filetype, size }, index) => (

--- a/src/components/document/SubTabs/components/Files/Files.tsx
+++ b/src/components/document/SubTabs/components/Files/Files.tsx
@@ -1,7 +1,7 @@
 import { Box, Table, TableBody, TableCell, TableRow } from '@mui/material'
 import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
-import { SyntheticEvent, useState } from 'react'
+import { SyntheticEvent, useEffect, useState } from 'react'
 
 import { createDownloadUrl, doc as docAPI } from '../../../../../backend/api'
 import { reactIcons } from '../../../../../constants/icons'
@@ -32,6 +32,10 @@ export const Files = observer(() => {
         setFiles([...(files || []), ...nextDoc.children])
         setFetchingChildrenPage(false)
     }
+
+    useEffect(() => {
+        setFiles(data?.children)
+    }, [data])
 
     const filesRows = files?.map(({ id, digest, file, filename, content_type, filetype, size }, index) => (
         <TableRow key={index}>

--- a/src/components/finder/FinderColumn.tsx
+++ b/src/components/finder/FinderColumn.tsx
@@ -1,9 +1,8 @@
-import { ButtonBase, CircularProgress, List, ListItem, ListItemIcon } from '@mui/material'
-import { FC, useState } from 'react'
+import { List } from '@mui/material'
+import { FC } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
-import { doc as docAPI } from '../../backend/api'
-import { reactIcons } from '../../constants/icons'
+import { Loading } from '../common/Loading/Loading'
 
 import { FinderItem } from './FinderItem'
 import { ColumnItem, LocalDocumentData } from './Types'
@@ -24,45 +23,12 @@ interface FinderColumnProps extends ColumnItem {
 export const FinderColumn: FC<FinderColumnProps> = ({ items, pathname, prevPage, nextPage, active, selected }) => {
     const { classes } = useStyles()
 
-    const [itemsState, setItemsState] = useState(items)
-    const [prevPageState, setPrevPageState] = useState(prevPage)
-    const [nextPageState, setNextPageState] = useState(nextPage)
-
-    const [prevPageLoading, setPrevPageLoading] = useState(false)
-    const [nextPageLoading, setNextPageLoading] = useState(false)
-
-    const handlePrevPage = async () => {
-        setPrevPageLoading(true)
-        const prevItems = await docAPI(pathname, prevPage)
-        setPrevPageLoading(false)
-        setPrevPageState(prevItems.children_page > 1 ? prevItems.children_page - 1 : undefined)
-        setItemsState((currentItems = []) => [...prevItems.children, ...currentItems])
-    }
-
-    const handleNextPage = async () => {
-        setNextPageLoading(true)
-        const nextItems = await docAPI(pathname, nextPage)
-        setNextPageLoading(false)
-        setNextPageState(nextItems.children_has_next_page ? nextItems.children_page + 1 : null)
-        setItemsState((currentItems = []) => [...currentItems, ...nextItems.children])
-    }
-
     return (
         <List dense disablePadding className={classes.column}>
-            {prevPageState && (
-                <ListItem component={ButtonBase} onClick={prevPageLoading ? undefined : handlePrevPage}>
-                    {prevPageLoading ? <CircularProgress size={18} thickness={5} /> : <ListItemIcon>{reactIcons.moreFiles}</ListItemIcon>}
-                </ListItem>
-            )}
-
-            {itemsState?.map((item) => (
-                <FinderItem key={item.id} pathname={pathname} item={item} active={active} selected={selected} />
-            ))}
-
-            {nextPageState && (
-                <ListItem component={ButtonBase} onClick={nextPageLoading ? undefined : handleNextPage}>
-                    {nextPageLoading ? <CircularProgress size={18} thickness={5} /> : <ListItemIcon>{reactIcons.moreFiles}</ListItemIcon>}
-                </ListItem>
+            {!items ? (
+                <Loading />
+            ) : (
+                items.map((item) => <FinderItem key={item.id} pathname={pathname} item={item} active={active} selected={selected} />)
             )}
         </List>
     )

--- a/src/components/finder/FinderColumn.tsx
+++ b/src/components/finder/FinderColumn.tsx
@@ -1,7 +1,9 @@
-import { List } from '@mui/material'
-import { FC } from 'react'
+import { ButtonBase, CircularProgress, List, ListItem, ListItemIcon } from '@mui/material'
+import { FC, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
+import { doc as docAPI } from '../../backend/api'
+import { reactIcons } from '../../constants/icons'
 import { Loading } from '../common/Loading/Loading'
 
 import { FinderItem } from './FinderItem'
@@ -23,12 +25,47 @@ interface FinderColumnProps extends ColumnItem {
 export const FinderColumn: FC<FinderColumnProps> = ({ items, pathname, prevPage, nextPage, active, selected }) => {
     const { classes } = useStyles()
 
+    const [itemsState, setItemsState] = useState(items)
+    const [prevPageState, setPrevPageState] = useState(prevPage)
+    const [nextPageState, setNextPageState] = useState(nextPage)
+
+    const [prevPageLoading, setPrevPageLoading] = useState(false)
+    const [nextPageLoading, setNextPageLoading] = useState(false)
+
+    const handlePrevPage = async () => {
+        setPrevPageLoading(true)
+        const prevItems = await docAPI(pathname, prevPage)
+        setPrevPageLoading(false)
+        setPrevPageState(prevItems.children_page > 1 ? prevItems.children_page - 1 : undefined)
+        setItemsState((currentItems = []) => [...prevItems.children, ...currentItems])
+    }
+
+    const handleNextPage = async () => {
+        setNextPageLoading(true)
+        const nextItems = await docAPI(pathname, nextPage)
+        setNextPageLoading(false)
+        setNextPageState(nextItems.children_has_next_page ? nextItems.children_page + 1 : null)
+        setItemsState((currentItems = []) => [...currentItems, ...nextItems.children])
+    }
+
     return (
         <List dense disablePadding className={classes.column}>
-            {!items ? (
+            {prevPageState && (
+                <ListItem component={ButtonBase} onClick={prevPageLoading ? undefined : handlePrevPage}>
+                    {prevPageLoading ? <CircularProgress size={18} thickness={5} /> : <ListItemIcon>{reactIcons.moreFiles}</ListItemIcon>}
+                </ListItem>
+            )}
+
+            {!itemsState ? (
                 <Loading />
             ) : (
-                items.map((item) => <FinderItem key={item.id} pathname={pathname} item={item} active={active} selected={selected} />)
+                itemsState.map((item) => <FinderItem key={item.id} pathname={pathname} item={item} active={active} selected={selected} />)
+            )}
+
+            {nextPageState && (
+                <ListItem component={ButtonBase} onClick={nextPageLoading ? undefined : handleNextPage}>
+                    {nextPageLoading ? <CircularProgress size={18} thickness={5} /> : <ListItemIcon>{reactIcons.moreFiles}</ListItemIcon>}
+                </ListItem>
             )}
         </List>
     )

--- a/src/components/finder/utils.ts
+++ b/src/components/finder/utils.ts
@@ -21,7 +21,9 @@ export const makeColumns = (doc: LocalDocumentData, pathname: string | null) => 
 
     if (doc.parent) {
         let node = doc
-        while (node.parent) {
+        // we have to restrict the length here as well due to docAPI caching/memoization
+        // which will return all parent hierarchy fetched so far 
+        while (node.parent && columns.length < 5) {
             createColumn(node.parent, node)
             node = node.parent
         }

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,7 +1,7 @@
 import { Button, FormControl, Grid, IconButton, InputAdornment, TextField, Tooltip, Typography } from '@mui/material'
 import { observer } from 'mobx-react-lite'
 import Router from 'next/router'
-import { cloneElement, FC, FormEvent, KeyboardEvent, useEffect } from 'react'
+import { cloneElement, FC, FormEvent, KeyboardEvent, useEffect, useRef } from 'react'
 
 import { tooltips } from '../../constants/help'
 import { reactIcons } from '../../constants/icons'
@@ -21,11 +21,12 @@ import { SortingMenu } from './sorting/SortingMenu/SortingMenu'
 
 export const Search: FC = observer(() => {
     const { classes } = useStyles()
+    const inputRef = useRef<HTMLInputElement>(null)
     const {
         searchStore: {
             search,
             searchViewStore: {
-                inputRef,
+                setInputRef,
                 setDrawerRef,
                 drawerWidth,
                 setDrawerWidth,
@@ -41,7 +42,7 @@ export const Search: FC = observer(() => {
 
     const clearInput = () => {
         clearSearchText()
-        inputRef.current?.focus()
+        inputRef?.current?.focus()
     }
 
     const clearSearchResults = (url: string) => {
@@ -58,6 +59,10 @@ export const Search: FC = observer(() => {
             Router.events.off('routeChangeStart', clearSearchResults)
         }
     })
+
+    useEffect(() => {
+        setInputRef(inputRef)
+    }, [inputRef, setInputRef])
 
     const handleSubmit = (event: FormEvent) => {
         event.preventDefault()

--- a/src/stores/HotKeysStore.ts
+++ b/src/stores/HotKeysStore.ts
@@ -12,7 +12,7 @@ export class HotKeysStore {
     constructor(private readonly hashStore: HashStateStore, private readonly documentStore: DocumentStore, private readonly searchStore: SearchStore) {
         makeAutoObservable(this)
 
-        const isInputFocused = () => searchStore.searchViewStore.inputRef.current === document.activeElement
+        const isInputFocused = () => searchStore.searchViewStore.inputRef?.current === document.activeElement
 
         this.keys = {
             nextItem: {

--- a/src/stores/search/SearchViewStore.ts
+++ b/src/stores/search/SearchViewStore.ts
@@ -1,5 +1,5 @@
 import { makeAutoObservable, reaction, runInAction } from 'mobx'
-import { ChangeEvent, useRef } from 'react'
+import { ChangeEvent, RefObject } from 'react'
 import { Entry } from 'type-fest'
 
 import { availableColumns } from '../../constants/availableColumns'
@@ -11,7 +11,7 @@ import { SearchStore } from './SearchStore'
 export type ResultsViewType = 'list' | 'table'
 
 export class SearchViewStore {
-    readonly inputRef = useRef<HTMLInputElement>()
+    inputRef: RefObject<HTMLInputElement> | undefined = undefined
 
     drawerRef: HTMLDivElement | undefined = undefined
 
@@ -42,6 +42,12 @@ export class SearchViewStore {
                 this.drawerWidth = drawerRef?.getBoundingClientRect().width
             }
         )
+    }
+
+    setInputRef = (inputRef: RefObject<HTMLInputElement>) => {
+        runInAction(() => {
+            this.inputRef = inputRef
+        })
     }
 
     setDrawerRef = (drawerRef: HTMLDivElement) => {


### PR DESCRIPTION

Title: Fix for Unnecessary Rerendering and Shared Store Instance Re-creation

Description:

In our application, we encountered a significant issue related to unnecessary re-rendering of the App component and subsequent creation of new shared store instances. This was primarily due to the way we managed the shared store. Also, memoization of the SharedStore was not possible since we were using hooks inside our classes used within the SharedStore, thus throwing an error when trying to memoize the instance of sharedStore.

Issue:

The App component was re-rendering on every pathname change, and the provider for the shared store was inline initializing a new store instance on every render with value={new SharedStore(user)}. This frequent re-initialization of the shared store was causing undesirable performance issues and complexity, and also flickering issues across the application.

Solution:

Moving the creation of the SharedStore instance into a useMemo hook. In order to successfully move the instance creation into a useMemo hook, I had to slightly refactor the inputRef within the SearchViewStore and how we assign it. In order to remove the only hook that is used inside SharedStore, thus allowing us to memoize the value.

The useMemo hook ensured that a new SharedStore instance was only created when its dependencies (the user) changed. Thus, on pathname changes, the App component would re-render, but it wouldn't result in the creation of a new SharedStore instance, thereby improving performance and predictability.