### PR TITLE
[EIC-966]: added location tab in search preview

### DIFF
--- a/src/components/Locations.js
+++ b/src/components/Locations.js
@@ -1,11 +1,12 @@
 import url from 'url'
 
-import { List, ListItem, ListItemIcon, Typography } from '@mui/material'
+import { List, ListItem, ListItemIcon, Typography, Box } from '@mui/material'
 import Link from 'next/link'
 import { memo, useEffect, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
 import { locations as locationsAPI } from '../backend/api'
+import { useSharedStore } from '../components/SharedStoreProvider'
 import { reactIcons } from '../constants/icons'
 
 import { Loading } from './common/Loading/Loading'
@@ -19,9 +20,20 @@ const useStyles = makeStyles()((theme) => ({
             color: theme.palette.error.main,
         },
     },
+    container: {
+        paddingTop: theme.spacing(2),
+    },
+    title: {
+        padding: `${theme.spacing(0.5)} ${theme.spacing(2)}`,
+    },
+    list: {
+        overflowY: 'auto',
+        height: 'calc(100% - 40px)'
+    }
 }))
 
 function Locations({ url: docUrl, data }) {
+    const { fullPage } = useSharedStore()
     const { classes } = useStyles()
     const [locations, setLocations] = useState([])
     const [error, setError] = useState(null)
@@ -73,38 +85,39 @@ function Locations({ url: docUrl, data }) {
     const basePath = url.parse(baseUrl).pathname
 
     return (
-        <List component="nav" dense>
-            <ListItem>
-                <Typography variant="h6">Locations</Typography>
-            </ListItem>
+        <Box className={classes.container} sx={{ height: fullPage ? '100%' : '40%' }}>
+            <Typography variant="h6" className={classes.title}>
+                Locations
+            </Typography>
+            <List component="nav" dense className={classes.list}>
+                {locations.length && (
+                    <>
+                        {locations.map((location) => (
+                            <Link key={location.id} href={`${basePath}${location.id}`} shallow {...(!fullPage && { target: '_blank' })}>
+                                <ListItem button>
+                                    <ListItemIcon>{reactIcons.location}</ListItemIcon>
 
-            {locations.length && (
-                <>
-                    {locations.map((location) => (
-                        <Link key={location.id} href={`${basePath}${location.id}`} shallow>
-                            <ListItem button>
-                                <ListItemIcon>{reactIcons.location}</ListItemIcon>
-
-                                <Typography style={{ wordBreak: 'break-all' }}>
-                                    {location.parent_path}/<em>{location.filename}</em>
-                                </Typography>
-                            </ListItem>
-                        </Link>
-                    ))}
-                </>
-            )}
-            {hasNextPage && (
-                <ListItem dense>
-                    {loadingNextPage ? (
-                        <Loading />
-                    ) : (
-                        <a href="#" onClick={loadMore}>
-                            load more...
-                        </a>
-                    )}
-                </ListItem>
-            )}
-        </List>
+                                    <Typography style={{ wordBreak: 'break-all' }}>
+                                        {location.parent_path}/<em>{location.filename}</em>
+                                    </Typography>
+                                </ListItem>
+                            </Link>
+                        ))}
+                    </>
+                )}
+                {hasNextPage && (
+                    <ListItem dense>
+                        {loadingNextPage ? (
+                            <Loading />
+                        ) : (
+                            <a href="#" onClick={loadMore}>
+                                load more...
+                            </a>
+                        )}
+                    </ListItem>
+                )}
+            </List>
+        </Box>
     )
 }
 

--- a/src/components/document/Document.tsx
+++ b/src/components/document/Document.tsx
@@ -9,6 +9,8 @@ import { specialTags } from '../../constants/specialTags'
 import { Tag } from '../../stores/TagsStore'
 import { getTagIcon } from '../../utils/utils'
 import { Loading } from '../common/Loading/Loading'
+import { Finder } from '../finder/Finder'
+import Locations from '../Locations'
 import { useSharedStore } from '../SharedStoreProvider'
 
 import { useStyles } from './Document.styles'
@@ -151,6 +153,17 @@ export const Document = observer(() => {
             icon: reactIcons.tagsTab,
             visible: !printMode && data.content.filetype !== 'folder',
             content: <Tags toolbarButtons={tagsLinks} />,
+        },
+        {
+            name: 'Location',
+            icon: reactIcons.location,
+            visible: !fullPage,
+            content: (
+                <>
+                    <Finder />
+                    <Locations data={data} url={digestUrl} />
+                </>
+            ),
         },
         {
             name: 'Meta',

--- a/src/components/finder/Finder.tsx
+++ b/src/components/finder/Finder.tsx
@@ -15,20 +15,27 @@ const useStyles = makeStyles()(() => ({
         display: 'flex',
         overflowX: 'auto',
     },
+    searchPreview: {
+        height: '60%',
+        borderBottom: '1px solid #d3d3d3',
+    },
 }))
 
 export const Finder: FC = observer(() => {
-    const { classes } = useStyles()
-    const { pathname, hierarchy } = useSharedStore().documentStore
+    const { classes, cx } = useStyles()
+    const {
+        fullPage,
+        documentStore: { pathname, hierarchy },
+    } = useSharedStore()
 
     const columns = useMemo(() => {
-        if (!pathname || !hierarchy) return [{} as ColumnItem];
-        return makeColumns(hierarchy, getBasePath(pathname))
-    }, [hierarchy, pathname])
+        if (!pathname || !hierarchy) return [{} as ColumnItem]
+        return makeColumns(hierarchy, getBasePath(pathname), !fullPage ? 1 : undefined)
+    }, [hierarchy, pathname, fullPage])
 
     return (
         <ErrorBoundary visible>
-            <div className={classes.container}>
+            <div className={cx(classes.container, { [classes.searchPreview]: !fullPage })}>
                 {columns.map(({ items, pathname, prevPage, nextPage, selected }, index) => (
                     <FinderColumn
                         key={pathname + index}

--- a/src/components/finder/FinderColumn.tsx
+++ b/src/components/finder/FinderColumn.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, CircularProgress, List, ListItem, ListItemIcon } from '@mui/material'
+import { ButtonBase, CircularProgress, List, ListItem, ListItemIcon, lighten } from '@mui/material'
 import { FC, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
@@ -15,6 +15,11 @@ const useStyles = makeStyles()(() => ({
         borderRight: '1px solid #d3d3d3',
         minWidth: 200,
         overflowY: 'auto',
+        '& .MuiListItem-root': {
+            '&:hover': {
+                backgroundColor: lighten('#dedede', 0.5),
+            },
+        },
     },
 }))
 

--- a/src/components/finder/FinderItem.tsx
+++ b/src/components/finder/FinderItem.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from 'tss-react/mui'
 
 import { ChildDocument, DocumentData } from '../../Types'
 import { getBasePath, getTypeIcon } from '../../utils/utils'
+import { useSharedStore } from '../SharedStoreProvider'
 
 import { filenameFor } from './utils'
 
@@ -14,11 +15,13 @@ const useStyles = makeStyles()((theme: Theme) => ({
         paddingRight: theme.spacing(0.5),
     },
     active: {
-        backgroundColor: '#1e90ff',
+        // added !important here in order to override the :hover styling of list items
+        // which apply a lighter background color
+        backgroundColor: '#1e90ff !important',
         color: '#fff',
     },
     selected: {
-        backgroundColor: '#dedede',
+        backgroundColor: '#dedede !important',
     },
     itemRoot: {
         margin: 0,
@@ -46,10 +49,11 @@ interface FinderItemProps {
 }
 
 export const FinderItem: FC<FinderItemProps> = ({ pathname, item, active, selected }) => {
+    const { fullPage } = useSharedStore()
     const { classes, cx } = useStyles()
     const ref = useRef<HTMLLIElement>(null)
     const router = useRouter()
-    const isActive = item.id === active?.id
+    const isActive = item.id === active?.id || item.digest === active?.id
     const isSelected = item.id === selected?.id
 
     useEffect(() => {
@@ -59,7 +63,12 @@ export const FinderItem: FC<FinderItemProps> = ({ pathname, item, active, select
     }, [isActive, isSelected])
 
     const handleClick = () => {
-        router.push(getBasePath(pathname) + ((item as any).file || item.id), undefined, { shallow: true })
+        const path = getBasePath(pathname) + ((item as any).file || item.id)
+        if (!fullPage) {
+            window.open(path, '_blank')
+        } else {
+            router.push(path, undefined, { shallow: true })
+        }
     }
 
     return (

--- a/src/components/finder/utils.ts
+++ b/src/components/finder/utils.ts
@@ -2,7 +2,9 @@ import { ChildDocument } from '../../Types'
 
 import { ColumnItem, LocalDocumentData } from './Types'
 
-export const makeColumns = (doc: LocalDocumentData, pathname: string | null) => {
+export const parentLevels = 4
+
+export const makeColumns = (doc: LocalDocumentData, pathname: string | null, limit?: number) => {
     const columns: ColumnItem[] = []
 
     const createColumn = (item: LocalDocumentData, selected: LocalDocumentData) => {
@@ -19,22 +21,24 @@ export const makeColumns = (doc: LocalDocumentData, pathname: string | null) => 
         createColumn(doc, doc)
     }
 
-    if (doc.parent) {
-        let node = doc
-        while (node.parent && columns.length < 5) {
-            createColumn(node.parent, node)
-            node = node.parent
-        }
+    let node = { ...doc }
+
+    while (node.parent && columns.length < (limit ?? parentLevels)) {
+        createColumn(node.parent, node)
+        node = node.parent
+    }
+
+    if (node.parent) {
         columns.unshift({
-            items: [node],
+            items: node.parent.children,
             pathname: pathname + node.id,
             selected: node,
         })
     } else {
         columns.unshift({
-            items: [doc],
+            items: [node],
             pathname: pathname + doc.id,
-            selected: doc,
+            selected: node,
         })
     }
 

--- a/src/stores/DocumentStore.ts
+++ b/src/stores/DocumentStore.ts
@@ -3,6 +3,7 @@ import { SyntheticEvent } from 'react'
 
 import { createDownloadUrl, createPreviewUrl, createThumbnailSrcSet, doc as docAPI } from '../backend/api'
 import { LocalDocumentData } from '../components/finder/Types'
+import { parentLevels } from '../components/finder/utils'
 import { DocumentData, OcrData, RequestError } from '../Types'
 import { collectionUrl, documentViewUrl, getBasePath } from '../utils/utils'
 
@@ -113,7 +114,6 @@ export class DocumentStore {
 
     getDocumentHierarchy = async () => {
         if (this.pathname && this.data) {
-            const parentLevels = 3
             const localData = { ...this.data }
             let current: LocalDocumentData | undefined = localData
             let level = 0


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/966

Added location tab in search preview. 
 - Finder will be 60% of width
 - Location component will be 40% of width
 
Made styling according to fullPage flag, to determine if these components are used within the full page of document view, or within the search preview.

Added hover effect for Finder column items.

fixed a bug where Finder would not display all list items in the latest parent column. This issue was inside the makeColumns util function