### PR TITLE
[EIC-1018]: added separate text & ocr tab

### DIFF
--- a/src/components/document/Document.tsx
+++ b/src/components/document/Document.tsx
@@ -15,6 +15,7 @@ import { useStyles } from './Document.styles'
 import { StyledTab } from './StyledTab'
 import { HTML } from './SubTabs/components/HTML'
 import { Meta } from './SubTabs/components/Meta/Meta'
+import { Preview, PREVIEWABLE_MIME_TYPE_SUFFEXES } from './SubTabs/components/Preview/Preview'
 import { Tags, getChipColor } from './SubTabs/components/Tags/Tags'
 import { TagTooltip } from './SubTabs/components/Tags/TagTooltip'
 import { Text } from './SubTabs/components/Text/Text'
@@ -138,10 +139,22 @@ export const Document = observer(() => {
         indicator: classes.tabsIndicator,
     }
 
+
+    const hasPreview =
+        data.content['has-pdf-preview'] ||
+        (docRawUrl && data.content['content-type'] && PREVIEWABLE_MIME_TYPE_SUFFEXES.some((x) => data.content['content-type'].endsWith(x)))
+
     const tabsData = [
         {
             name: data.content.filetype,
             icon: reactIcons.contentTab,
+            visible: hasPreview,
+            padding: 0,
+            content: <Preview />,
+        },
+        {
+            name: 'Text',
+            icon: reactIcons.content,
             visible: true,
             padding: 0,
             content: <SubTabs />,

--- a/src/components/document/SubTabs/SubTabs.tsx
+++ b/src/components/document/SubTabs/SubTabs.tsx
@@ -1,17 +1,12 @@
 import { Box, Tab, Tabs, Typography } from '@mui/material'
 import { observer } from 'mobx-react-lite'
-import { cloneElement, ReactElement } from 'react'
+import { ReactElement } from 'react'
 
-import { createOcrUrl } from '../../../backend/api'
 import { reactIcons } from '../../../constants/icons'
-import { Expandable } from '../../common/Expandable/Expandable'
-import PDFViewer from '../../pdf-viewer/Dynamic'
 import { useSharedStore } from '../../SharedStoreProvider'
 import { TabPanel } from '../TabPanel/TabPanel'
 
 import { Email } from './components/Email/Email'
-import { Files } from './components/Files/Files'
-import { Preview, PREVIEWABLE_MIME_TYPE_SUFFEXES } from './components/Preview/Preview'
 import { Text } from './components/Text/Text'
 import { useStyles } from './SubTabs.styles'
 
@@ -26,16 +21,12 @@ export const SubTabs = observer(() => {
     const { classes } = useStyles()
     const {
         printMode,
-        documentStore: { data, digestUrl, docRawUrl, ocrData, collection, subTab, handleSubTabChange },
+        documentStore: { data, ocrData, collection, subTab, handleSubTabChange },
     } = useSharedStore()
 
     if (!data || !collection || !ocrData) {
         return null
     }
-
-    const hasPreview =
-        data.content['has-pdf-preview'] ||
-        (docRawUrl && data.content['content-type'] && PREVIEWABLE_MIME_TYPE_SUFFEXES.some((x) => data.content['content-type'].endsWith(x)))
 
     const tabs = [
         {
@@ -71,34 +62,6 @@ export const SubTabs = observer(() => {
 
             <Box className={classes.subTab}>
                 {data.content.filetype === 'email' && <Email />}
-
-                {tabs.map(({ tag }, index) => {
-                    if (subTab === index && hasPreview && !tag?.startsWith('translated_')) {
-                        if (index !== 0 && digestUrl && data.content['content-type'] === 'application/pdf') {
-                            return <PDFViewer key={index} url={createOcrUrl(digestUrl, tag)} />
-                        } else {
-                            return <Preview key={index} />
-                        }
-                    }
-                })}
-
-                {!!data.children?.length && (
-                    <Box>
-                        <Expandable
-                            resizable
-                            defaultOpen
-                            highlight={false}
-                            fullHeight={false}
-                            title={
-                                <>
-                                    {cloneElement(reactIcons.contentFiles, { className: classes.icon })}
-                                    Files
-                                </>
-                            }>
-                            <Files />
-                        </Expandable>
-                    </Box>
-                )}
 
                 {tabs.map(({ name, content }, index) => (
                     <Box key={index}>

--- a/src/components/pdf-viewer/Document.js
+++ b/src/components/pdf-viewer/Document.js
@@ -20,6 +20,9 @@ const useStyles = makeStyles()((theme) => ({
         padding: theme.spacing(3),
     },
     viewer: {
+        height: '100%',
+        display: 'flex',
+        flexFlow: 'column',
         '&:fullscreen': {
             '& $container': {
                 height: 'calc(100vh - 48px)',
@@ -37,7 +40,7 @@ const useStyles = makeStyles()((theme) => ({
         display: 'none',
     },
     container: {
-        height: '50vh',
+        flex: 1,
         overflow: 'auto',
         position: 'relative',
         boxSizing: 'content-box',


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1018

Removed the Files component within the Preview Tab, since we've created a Locations tab in a separate story: #339

Extracted the document preview in a separate tab and component, and left the SubTabs component with the Text and OCR subtabs.