### PR TITLE
[EIC-1052]: fixed filename and path errors thrown

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -282,7 +282,7 @@ export interface OcrData {
 
 export interface ChildDocument {
     id: string
-    filename: string
+    filename: string[]
     filetype: string
     content_type: string
     digest?: string
@@ -292,7 +292,7 @@ export interface ChildDocument {
 
 export interface DocumentContent {
     id: string
-    filename: string
+    filename: string[]
     filetype: string
     'has-pdf-preview': boolean
     'has-thumbnails': boolean
@@ -314,7 +314,7 @@ export interface DocumentContent {
     'entity-type.location': string[]
     'entity-type.organization': string[]
     'entity-type.person': string[]
-    path: string
+    path: string[]
     'path-parts': string[]
     'path-text': string
     tika: string[]

--- a/src/components/document/DocPage/DocPage.tsx
+++ b/src/components/document/DocPage/DocPage.tsx
@@ -23,6 +23,8 @@ export const DocPage: FC = observer(() => {
         documentStore: { data, loading, error, digest, digestUrl, urlIsSha },
     } = useSharedStore()
 
+    const [fileName] = data?.content.filename ?? ['']
+
     if (error) {
         return (
             <Error
@@ -60,7 +62,7 @@ export const DocPage: FC = observer(() => {
             <>
                 {data && (
                     <Typography variant="subtitle2" className={classes.title}>
-                        Document <b>{data?.id}</b> filename: <b>{shortenName(data?.content.filename, 50)}</b> - please pick a location to see the Finder
+                        Document <b>{data?.id}</b> filename: <b>{shortenName(fileName, 50)}</b> - please pick a location to see the Finder
                     </Typography>
                 )}
                 <div className={classes.splitPane}>{infoPane}</div>
@@ -70,7 +72,7 @@ export const DocPage: FC = observer(() => {
                 <Typography variant="subtitle2" className={classes.title}>
                     {data ? (
                         <>
-                            {!!digest ? 'File' : 'Directory'} <b>{data.content.path}</b>
+                            {!!digest ? 'File' : 'Directory'} <b>{data.content?.path?.[0] ?? ''}</b>
                         </>
                     ) : (
                         <CircularProgress size={16} thickness={4} />
@@ -106,7 +108,7 @@ export const DocPage: FC = observer(() => {
     return (
         <>
             <Head>
-                <title>{`Hoover ${data && `- ${data.content.filename}`}`}</title>
+                <title>{`Hoover ${data && `- ${fileName}`}`}</title>
                 {user.urls.hypothesis_embed && (
                     <>
                         <script async src={user.urls.hypothesis_embed} />

--- a/src/components/document/Document.tsx
+++ b/src/components/document/Document.tsx
@@ -232,7 +232,7 @@ export const Document = observer(() => {
                 <Grid item className={classes.titleWrapper}>
                     <Box>
                         <Typography variant="h5" className={classes.filename}>
-                            {data.content.filename}
+                            {data.content?.filename?.[0] ?? ''}
                         </Typography>
                     </Box>
 

--- a/src/components/document/SubTabs/components/Files/Files.tsx
+++ b/src/components/document/SubTabs/components/Files/Files.tsx
@@ -43,12 +43,12 @@ export const Files = observer(() => {
     const filesRows = files?.map(({ id, digest, file, filename, content_type, filetype, size }, index) => (
         <TableRow key={index}>
             <TableCell className={classes.cell}>
-                {id ? <Link href={`${collectionBaseUrl}/${file || id}`}>{filename}</Link> : <span>{filename}</span>}
+                {id ? <Link href={`${collectionBaseUrl}/${file || id}`}>{filename?.[0]}</Link> : <span>{filename?.[0]}</span>}
             </TableCell>
             <TableCell className={classes.cell}>
                 {digest && (
                     <a
-                        href={createDownloadUrl(`${collectionBaseUrl}/${digest}`, filename)}
+                        href={createDownloadUrl(`${collectionBaseUrl}/${digest}`, filename?.[0])}
                         target={fullPage ? undefined : '_blank'}
                         rel="noreferrer"
                         title="Original file"

--- a/src/components/document/SubTabs/components/Meta/Meta.tsx
+++ b/src/components/document/SubTabs/components/Meta/Meta.tsx
@@ -156,13 +156,15 @@ export const Meta = observer(() => {
                 {Object.entries(tableFields)
                     .filter(([, config]) => !config.visible || config.visible(data?.content) !== false)
                     .map(([field, config]) => {
+                        const fieldContent = (data?.content[field as keyof DocumentContent] as string)
+                        const fieldValue = Array.isArray(fieldContent) ? fieldContent[0] : fieldContent
                         const display = config.format
                             ? config.format(data?.content?.[field as keyof DocumentContent])
-                            : (data?.content[field as keyof DocumentContent] as string)
+                            : fieldValue
                         const searchKey = config.searchKey || field
                         const searchTerm = config.searchTerm
                             ? config.searchTerm(data?.content?.[field as keyof DocumentContent])
-                            : data?.content[field as keyof DocumentContent]
+                            : fieldValue
 
                         return (
                             <ListItem key={field} disableGutters>

--- a/src/components/document/SubTabs/components/Preview/Preview.tsx
+++ b/src/components/document/SubTabs/components/Preview/Preview.tsx
@@ -84,7 +84,7 @@ export const Preview: FC = () => {
                 type={data?.content['content-type']}
                 height="100%"
                 width="100%"
-                title={data?.content.filename}
+                title={data?.content.filename[0] ?? ''}
             />
         </div>
     )

--- a/src/components/finder/utils.ts
+++ b/src/components/finder/utils.ts
@@ -46,10 +46,13 @@ export const makeColumns = (doc: LocalDocumentData, pathname: string | null, lim
 }
 
 export const filenameFor = (item: Partial<LocalDocumentData & ChildDocument>) => {
-    if (item.filename) {
-        return item.filename
-    } else {
-        const { filename, path } = item.content || {}
-        return filename || path?.split('/').filter(Boolean).pop() || path || '/'
-    }
+    if (item.filename) return item.filename
+
+    const { filename, path } = item.content ?? {}
+    if (filename) return filename[0]
+    if (!path) return '/'
+
+    const something = Array.isArray(path) ? path[0] : path
+    return something?.split('/').filter(Boolean).pop()
 }
+  

--- a/src/components/pdf-viewer/AttachmentsView.js
+++ b/src/components/pdf-viewer/AttachmentsView.js
@@ -27,7 +27,7 @@ function AttachmentsView() {
                             ? []
                             : Object.keys(response).map((file) => ({
                                   data: response[file].content,
-                                  fileName: response[file].filename,
+                                  fileName: response[file].filename?.[0] ?? '',
                               }))
                     )
                 })

--- a/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
+++ b/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
@@ -68,7 +68,8 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
     const fields = hit._source || {}
     const highlights = hit.highlight || {}
     const collection = hit._collection || ''
-    const downloadUrl = createDownloadUrl(url, fields.filename)
+    const [fileName] = fields.filename ?? ['']
+    const downloadUrl = createDownloadUrl(url, fileName)
 
     const cardHeaderClasses = {
         action: classes.cardHeaderAction,
@@ -95,7 +96,7 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
                                 <Box component="span" className={classes.index}>
                                     {index}.
                                 </Box>{' '}
-                                {fields.filename}
+                                {fileName}
                             </Grid>
 
                             <Grid container component="span">
@@ -140,7 +141,7 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
 
                             <Grid item component="span" className={classes.title}>
                                 <Typography variant="body1" className={classes.title} component="span" color="textSecondary">
-                                    {truncatePath(fields.path)}
+                                    {truncatePath(fields.path?.[0] ?? '')}
                                 </Typography>
                             </Grid>
                         </Grid>

--- a/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.tsx
+++ b/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.tsx
@@ -33,7 +33,7 @@ export const ResultsTableRow: FC<ResultsTableRowProps> = observer(({ hit, index 
     const url = documentViewUrl(hit)
     const fields = hit._source || {}
     const collection = hit._collection || ''
-    const downloadUrl = createDownloadUrl(url, fields.filename)
+    const downloadUrl = createDownloadUrl(url, fields.filename[0] ?? '')
     const isPreview = collection === hashState.preview?.c && hit._id === hashState.preview?.i
 
     const handleResultClick = () => {

--- a/src/stores/DocumentStore.ts
+++ b/src/stores/DocumentStore.ts
@@ -166,7 +166,7 @@ export class DocumentStore {
     setFileDocumentAttributes = (data: DocumentData) => {
         this.digest = data.digest
         this.digestUrl = `${this.collectionBaseUrl}/${data.digest}`
-        this.docRawUrl = createDownloadUrl(`${this.collectionBaseUrl}/${data.digest}`, data.content.filename)
+        this.docRawUrl = createDownloadUrl(`${this.collectionBaseUrl}/${data.digest}`, data.content?.filename?.[0] ?? '')
         this.docPreviewUrl = createPreviewUrl(`${this.collectionBaseUrl}/${data.digest}`)
         this.thumbnailSrcSet = createThumbnailSrcSet(`${this.collectionBaseUrl}/${data.digest}`)
         this.urlIsSha = false
@@ -182,7 +182,7 @@ export class DocumentStore {
 
     setShaDocumentAttributes = (data: DocumentData) => {
         this.digest = data.id
-        this.docRawUrl = createDownloadUrl(`${this.collectionBaseUrl}/${data.id}`, data.content.filename)
+        this.docRawUrl = createDownloadUrl(`${this.collectionBaseUrl}/${data.id}`, data.content?.filename?.[0] ?? '')
         this.docPreviewUrl = createPreviewUrl(`${this.collectionBaseUrl}/${data.id}`)
         this.thumbnailSrcSet = createThumbnailSrcSet(`${this.collectionBaseUrl}/${data.id}`)
     }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -107,22 +107,36 @@ export const makeUnsearchable = (text: string) => {
 }
 
 export const truncatePath = (str: string) => {
-    if (str.length < 100) {
+    try {
+        if (str.length < 100) {
+            return str
+        }
+
+        const parts = str.split('/')
+
+        return [...parts.slice(0, parts.length / 3), '…', ...parts.slice(-(parts.length / 3))].join('/')
+    } catch (error) {
+        console.error('An error occurred while truncating path:', error)
         return str
     }
-    const parts = str.split('/')
-
-    return [...parts.slice(0, parts.length / 3), '…', ...parts.slice(-(parts.length / 3))].join('/')
 }
 
-export const shortenName = (name: string | undefined, length = ELLIPSIS_TERM_LENGTH) =>
-    name && name.length > length ? (
-        <Tooltip title={name}>
-            <span>{`${name.substr(0, (2 / 3) * length - 3)}...${name.substr((-1 / 3) * length)}`}</span>
-        </Tooltip>
-    ) : (
-        name
-    )
+export const shortenName = (name: string | undefined, length = ELLIPSIS_TERM_LENGTH) => {
+    if (!name) return undefined
+    if (name.length < length) return name
+
+    try {
+        const shortenedName = `${name.substr(0, (2 / 3) * length - 3)}...${name.substr((-1 / 3) * length)}`
+        return (
+            <Tooltip title={name}>
+                <span>{shortenedName}</span>
+            </Tooltip>
+        )
+    } catch (error) {
+        console.error('An error occurred while shortening field name: ', error)
+        return 'undefined'
+    }
+}
 
 export const formatThousands = (number: number) => {
     let decimalPart = ''
@@ -144,10 +158,20 @@ export const formatThousands = (number: number) => {
 }
 
 export const copyMetadata = (doc: DocumentData) => {
-    const string = [doc.content.md5, doc.content.path].join('\n')
-
-    return copy(string) ? `Copied MD5 and path to clipboard` : `Could not copy meta metadata – unsupported browser?`
-}
+    const { md5, path } = doc.content;
+  
+    let string = md5;
+    if (path && Array.isArray(path) && path.length > 0) {
+      string += `\n${path[0]}`;
+    }
+  
+    if (copy(string)) {
+      return `Copied MD5 and path to clipboard`;
+    } else {
+      return `Could not copy meta metadata - unsupported browser?`;
+    }
+  };
+  
 
 const documentUrlPrefix = '/doc'
 export const collectionUrl = (collection: string) => [documentUrlPrefix, collection].join('/')


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1052

Refactored all `filename` and `path` data manipulation to the new format of `string[]` instead of previous `string`