### PR TITLE
[EIC-1095]: brought back OCR tabs for PDF viewer

### DIFF
--- a/src/components/document/Document.tsx
+++ b/src/components/document/Document.tsx
@@ -18,7 +18,8 @@ import { useStyles } from './Document.styles'
 import { StyledTab } from './StyledTab'
 import { HTML } from './SubTabs/components/HTML'
 import { Meta } from './SubTabs/components/Meta/Meta'
-import { Preview, PREVIEWABLE_MIME_TYPE_SUFFEXES } from './SubTabs/components/Preview/Preview'
+import { PdfTab } from './SubTabs/components/Preview/PdfTab'
+import { PREVIEWABLE_MIME_TYPE_SUFFEXES } from './SubTabs/components/Preview/Preview'
 import { getChipColor, Tags } from './SubTabs/components/Tags/Tags'
 import { TagTooltip } from './SubTabs/components/Tags/TagTooltip'
 import { Text } from './SubTabs/components/Text/Text'
@@ -29,7 +30,6 @@ import { Toolbar, ToolbarLink } from './Toolbar/Toolbar'
 export const Document = observer(() => {
     const { classes } = useStyles()
     const containerRef = useRef<HTMLDivElement>(null)
-    const [isEventAdded, setIsEventAdded] = useState(false)
 
     const {
         user,
@@ -154,7 +154,7 @@ export const Document = observer(() => {
         root: classes.tabsRoot,
         indicator: classes.tabsIndicator,
     }
-
+    
 
     const hasPreview =
         data.content['has-pdf-preview'] ||
@@ -166,7 +166,7 @@ export const Document = observer(() => {
             icon: reactIcons.contentTab,
             visible: hasPreview,
             padding: 0,
-            content: <Preview />,
+            content: <PdfTab />,
             searchLoading: pdfSearchStore.loading,
             searchCount: pdfSearchStore.getSearchResultsCount()
         },

--- a/src/components/document/SubTabs/SubTabs.tsx
+++ b/src/components/document/SubTabs/SubTabs.tsx
@@ -2,7 +2,6 @@ import { Box, Tab, Tabs, Typography } from '@mui/material'
 import { observer } from 'mobx-react-lite'
 import { ReactElement, useEffect } from 'react'
 
-import { reactIcons } from '../../../constants/icons'
 import { Loading } from '../../common/Loading/Loading'
 import { useSharedStore } from '../../SharedStoreProvider'
 import { TabPanel } from '../TabPanel/TabPanel'
@@ -11,18 +10,12 @@ import { Email } from './components/Email/Email'
 import { Text } from './components/Text/Text'
 import { useStyles } from './SubTabs.styles'
 
-interface Tab {
-    tag: string
-    name: string
-    icon: ReactElement
-    content: string
-}
-
 export const SubTabs = observer(() => {
     const { classes } = useStyles()
     const {
         printMode,
         documentStore: {
+            tabs,
             data,
             ocrData,
             collection,
@@ -39,26 +32,6 @@ export const SubTabs = observer(() => {
     if (!data || !collection || !ocrData) {
         return null
     }
-
-    const tabs = [
-        {
-            name: 'Extracted from file',
-            icon: reactIcons.content,
-            content: data.content.text,
-        } as Tab,
-    ]
-
-    tabs.push(
-        ...ocrData.map(
-            ({ tag, text }) =>
-                ({
-                    tag,
-                    name: (tag.startsWith('translated_') ? '' : 'OCR ') + tag,
-                    icon: reactIcons.ocr,
-                    content: text,
-                } as Tab)
-        )
-    )
 
     return (
         <>

--- a/src/components/document/SubTabs/components/Preview/PdfTab.tsx
+++ b/src/components/document/SubTabs/components/Preview/PdfTab.tsx
@@ -1,0 +1,60 @@
+import { Box, Tab, Tabs } from '@mui/material'
+import { observer } from 'mobx-react-lite'
+import { useEffect } from 'react'
+
+import { createOcrUrl } from '../../../../../backend/api'
+import PDFViewer from '../../../../pdf-viewer/Dynamic'
+import { useSharedStore } from '../../../../SharedStoreProvider'
+import { useStyles } from '../../SubTabs.styles'
+
+import { Preview } from './Preview'
+
+export const PdfTab = observer(() => {
+    const { classes } = useStyles()
+    const {
+        printMode,
+        documentStore: {
+            tabs,
+            data,
+            digestUrl,
+            ocrData,
+            collection,
+            subTab,
+            handleSubTabChange,
+            documentSearchStore: { setActiveSearch, pdfSearchStore },
+        },
+    } = useSharedStore()
+
+    useEffect(() => {
+        setActiveSearch(pdfSearchStore)
+    }, [setActiveSearch, pdfSearchStore])
+
+    if (!data || !collection || !ocrData) {
+        return null
+    }
+
+    return (
+        <>
+            {!printMode && tabs.length > 1 && (
+                <Box>
+                    <Tabs value={subTab} onChange={handleSubTabChange} variant="scrollable" scrollButtons="auto">
+                        {tabs.map(({ icon, name }, index) => (
+                            <Tab key={index} icon={icon} label={name} />
+                        ))}
+                    </Tabs>
+                </Box>
+            )}
+            <Box className={classes.subTab}>
+                {tabs.map(({ tag }, index) => {
+                    if (subTab === index && !tag?.startsWith('translated_')) {
+                        if (index !== 0 && digestUrl && data.content['content-type'] === 'application/pdf') {
+                            return <PDFViewer key={index} url={createOcrUrl(digestUrl, tag)} />
+                        } else {
+                            return <Preview key={index} />
+                        }
+                    }
+                })}
+            </Box>
+        </>
+    )
+})

--- a/src/components/document/SubTabs/components/Preview/Preview.tsx
+++ b/src/components/document/SubTabs/components/Preview/Preview.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react'
+import { FC } from 'react'
 
 import PDFViewer from '../../../../pdf-viewer/Dynamic'
 import { useSharedStore } from '../../../../SharedStoreProvider'
@@ -47,13 +47,8 @@ export const Preview: FC = () => {
             data,
             docRawUrl,
             docPreviewUrl,
-            documentSearchStore: { setActiveSearch, pdfSearchStore },
         },
     } = useSharedStore()
-    
-    useEffect(() => {
-        setActiveSearch(pdfSearchStore)
-    }, [setActiveSearch, pdfSearchStore])
 
     if (data?.content['has-pdf-preview']) {
         return <PDFViewer url={docPreviewUrl} />


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1095

I've just reverted some of the changes that I've made in https://github.com/liquidinvestigations/hoover-ui/commit/6ce75d1a4c8a10300fd37cec77ad080424d4e5a7

OCR tabs should have not been removed for PDF viewer. I've moved the tabs data to the document store and now both text and PDF use them.