### PR TITLE
[EIC-1182]: added fallback in case pdf info request fails

### DIFF
--- a/src/components/pdf-viewer/Viewer.tsx
+++ b/src/components/pdf-viewer/Viewer.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from 'react'
 
-import { X_HOOVER_PDF_SPLIT_PAGE_RANGE } from '../../backend/api'
 import { useSharedStore } from '../SharedStoreProvider'
 
 import { Document } from './Document/Document'
@@ -26,7 +25,6 @@ interface ViewerProps {
 export const Viewer: FC<ViewerProps> = ({ url, cMapUrl = '/build/static/cmaps', cMapPacked = true, withCredentials = true }) => {
     const {
         hashStore: { hashState, setHashState },
-        documentStore: { chunkTab, pdfDocumentInfo },
     } = useSharedStore()
     const [pageIndex, setPageIndex] = useState(0)
 
@@ -49,14 +47,8 @@ export const Viewer: FC<ViewerProps> = ({ url, cMapUrl = '/build/static/cmaps', 
         }
     }, 300)
 
-    const getDocumentUrl = () => {
-        const { chunks } = pdfDocumentInfo ?? {}
-        if (!chunks || chunks.length < 2) return url
-        return `${url}?${X_HOOVER_PDF_SPLIT_PAGE_RANGE}=${chunks[chunkTab]}`
-    }
-
     return (
-        <DocumentProvider url={getDocumentUrl()} cMapUrl={cMapUrl} cMapPacked={cMapPacked} withCredentials={withCredentials}>
+        <DocumentProvider url={url} cMapUrl={cMapUrl} cMapPacked={cMapPacked} withCredentials={withCredentials}>
             <Document initialPageIndex={pageIndex} onPageIndexChange={onPageIndexChange} />
         </DocumentProvider>
     )


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1182

Just moved some logic between components/scopes, and added a try catch block in order for the document Provider to continue and have a fallback to the original PDF viewer which does not use the new chunking system of the files.