### PR TITLE
added deduplication feature with hiding and marking

### DIFF
--- a/__test__/__snapshots__/buildSearchQuery.test.js.snap
+++ b/__test__/__snapshots__/buildSearchQuery.test.js.snap
@@ -835,6 +835,7 @@ exports[`builds a default query 1`] = `
     },
   },
   "collections": [],
+  "dedup_collections": undefined,
   "from": 0,
   "highlight": {
     "fields": {},

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -95,6 +95,8 @@ export interface SearchQueryParams {
     order?: string[][]
     facets?: Record<string, number>
     filters?: Record<string, Terms>
+    dedup_results?: number
+    dedup_collections?: string[]
 }
 
 export interface BatchSearchQueryParams {
@@ -232,6 +234,8 @@ export interface Hit {
     _source: DocumentContent
     _type: string
     _url_rel: string
+    _dedup_hide_result: boolean
+    _dedup_hits: string[]
 }
 
 export interface Bucket {

--- a/src/backend/buildSearchQuery.ts
+++ b/src/backend/buildSearchQuery.ts
@@ -15,6 +15,7 @@ import type {
 
 interface MsearchMultisearchBodyWithCollections extends MsearchMultisearchBody {
     collections: string[]
+    dedup_collections?: string[]
 }
 
 export interface SearchFields {
@@ -387,7 +388,7 @@ const getAggregationFields = (type: FieldType, fieldList: FieldList) =>
         .filter((field) => fieldList === '*' || (Array.isArray(fieldList) && fieldList.includes(field))) as SourceField[]
 
 const buildSearchQuery = (
-    { q = '*', page = 1, size = 0, order, collections = [], facets = {}, filters = {} }: Partial<SearchQueryParams> = {},
+    { q = '*', page = 1, size = 0, order, collections = [], dedup_collections, facets = {}, filters = {} }: Partial<SearchQueryParams> = {},
     type: SearchQueryType,
     fieldList: FieldList,
     missing: boolean,
@@ -432,6 +433,7 @@ const buildSearchQuery = (
         post_filter: postFilter,
         aggs: type === 'results' ? {} : aggs,
         collections,
+        dedup_collections: type === 'results' && dedup_collections?.length ? dedup_collections : undefined,
         _source: searchFields._source,
         highlight: {
             fields: highlightFields,

--- a/src/components/search/SearchViewOptions/SearchViewOptions.tsx
+++ b/src/components/search/SearchViewOptions/SearchViewOptions.tsx
@@ -1,7 +1,9 @@
-import { Fab, Grid } from '@mui/material'
+import { Checkbox, Fab, FormControlLabel, Grid } from '@mui/material'
+import { useTranslate } from '@tolgee/react'
 import { observer } from 'mobx-react-lite'
 
 import { reactIcons } from '../../../constants/icons'
+import { DEDUPLICATE_OPTIONS } from '../../../consts'
 import { useSharedStore } from '../../SharedStoreProvider'
 import { SearchFields } from '../filters/SearchFields/SearchFields'
 import { SortingChips } from '../sorting/SortingChips/SortingChips'
@@ -10,56 +12,81 @@ import { SortingMenu } from '../sorting/SortingMenu/SortingMenu'
 import { useStyles } from './SearchViewOptions.style'
 
 export const SearchViewOptions = observer(() => {
+    const { t } = useTranslate()
     const { classes } = useStyles()
     const {
         fields,
         searchStore: {
-            searchViewStore: { resultsViewType, setResultsViewType, toggleDateDetails, showDateInsights },
+            query,
+            searchViewStore: { resultsViewType, setResultsViewType, toggleDateDetails, showDateInsights, handleDeduplicateResults },
         },
     } = useSharedStore()
 
     return (
-        <Grid container justifyContent="space-between" mt={1}>
-            <Grid item>
-                <Grid container spacing={0.5}>
-                    <Grid item>
-                        <Fab
-                            size="small"
-                            color={resultsViewType === 'list' ? 'primary' : 'default'}
-                            className={classes.viewTypeIcon}
-                            onClick={() => setResultsViewType('list')}>
-                            {reactIcons.listView}
-                        </Fab>
-                    </Grid>
-                    <Grid item>
-                        <Fab
-                            size="small"
-                            color={resultsViewType === 'table' ? 'primary' : 'default'}
-                            className={classes.viewTypeIcon}
-                            onClick={() => setResultsViewType('table')}>
-                            {reactIcons.tableView}
-                        </Fab>
-                    </Grid>
-                </Grid>
-            </Grid>
-            <Grid item>
-                <Grid container spacing={0.5}>
-                    <Grid item>
-                        <Fab size="small" color={showDateInsights ? 'primary' : 'default'} className={classes.viewTypeIcon} onClick={toggleDateDetails}>
-                            {reactIcons.categoryDates}
-                        </Fab>
-                    </Grid>
-                    {fields?.all && (
+        <>
+            <Grid container justifyContent="space-between" mt={1}>
+                <Grid item>
+                    <Grid container spacing={0.5}>
                         <Grid item>
-                            <SearchFields />
+                            <Fab
+                                size="small"
+                                color={resultsViewType === 'list' ? 'primary' : 'default'}
+                                className={classes.viewTypeIcon}
+                                onClick={() => setResultsViewType('list')}>
+                                {reactIcons.listView}
+                            </Fab>
                         </Grid>
-                    )}
-                    <Grid item>
-                        <SortingChips />
-                        <SortingMenu />
+                        <Grid item>
+                            <Fab
+                                size="small"
+                                color={resultsViewType === 'table' ? 'primary' : 'default'}
+                                className={classes.viewTypeIcon}
+                                onClick={() => setResultsViewType('table')}>
+                                {reactIcons.tableView}
+                            </Fab>
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Grid item>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                size="small"
+                                tabIndex={-1}
+                                disableRipple
+                                checked={query?.dedup_results === DEDUPLICATE_OPTIONS.hide}
+                                indeterminate={query?.dedup_results === DEDUPLICATE_OPTIONS.mark}
+                                onClick={handleDeduplicateResults}
+                            />
+                        }
+                        label={t('dedup_results', 'Deduplicate results')}
+                    />
+                </Grid>
+                <Grid item>
+                    <Grid container spacing={0.5}>
+                        <Grid item>
+                            <Fab
+                                size="small"
+                                color={showDateInsights ? 'primary' : 'default'}
+                                className={classes.viewTypeIcon}
+                                onClick={toggleDateDetails}>
+                                {reactIcons.categoryDates}
+                            </Fab>
+                        </Grid>
+                        {fields?.all && (
+                            <Grid item>
+                                <SearchFields />
+                            </Grid>
+                        )}
+                        <Grid item>
+                            <SortingMenu />
+                        </Grid>
                     </Grid>
                 </Grid>
             </Grid>
-        </Grid>
+            <Grid container justifyContent="end" mt={1}>
+                <SortingChips />
+            </Grid>
+        </>
     )
 })

--- a/src/components/search/results/resultsList/ResultItem/ResultItem.styles.ts
+++ b/src/components/search/results/resultsList/ResultItem/ResultItem.styles.ts
@@ -126,4 +126,8 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     previewImgLoading: {
         width: 1,
     },
+
+    duplicate: {
+        opacity: 0.5,
+    },
 }))

--- a/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
+++ b/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
@@ -7,6 +7,7 @@ import { cloneElement, useEffect, useRef, useState } from 'react'
 import { createDownloadUrl, createThumbnailSrc, createThumbnailSrcSet } from '../../../../../backend/api'
 import { reactIcons } from '../../../../../constants/icons'
 import { specialTags, specialTagsList } from '../../../../../constants/specialTags'
+import { DEDUPLICATE_OPTIONS } from '../../../../../consts'
 import { getTypeIcon, humanFileSize, makeUnsearchable, truncatePath, extractStringFromField } from '../../../../../utils/utils'
 import { Loading } from '../../../../common/Loading/Loading'
 import { useSharedStore } from '../../../../SharedStoreProvider'
@@ -39,6 +40,7 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
         user,
         hashStore: { hashState },
         searchStore: {
+            query,
             searchResultsStore: { openPreview },
         },
     } = useSharedStore()
@@ -98,7 +100,10 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
     return (
         <Card
             ref={nodeRef}
-            className={cx(classes.card, { [classes.selected]: isPreview })}
+            className={cx(classes.card, {
+                [classes.selected]: isPreview,
+                [classes.duplicate]: query?.dedup_results === DEDUPLICATE_OPTIONS.mark && hit._dedup_hide_result,
+            })}
             onMouseDown={handleMouseDown}
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
@@ -153,6 +158,12 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
                                 <Grid item component="span" className={classes.collection}>
                                     {collection}
                                 </Grid>
+                                {hit._dedup_hide_result && (
+                                    <Grid item component="span" className={classes.collection} ml={2}>
+                                        {reactIcons.fileCopy} {t('duplicate', 'Duplicate')}: [
+                                        {hit._dedup_hits.filter((x) => x !== collection).toString()}]
+                                    </Grid>
+                                )}
                             </Grid>
 
                             <Grid item component="span" className={classes.title}>

--- a/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
+++ b/src/components/search/results/resultsList/ResultItem/ResultItem.tsx
@@ -160,7 +160,7 @@ export const ResultItem: FC<ResultItemProps> = observer(({ hit, url, index }) =>
                                 </Grid>
                                 {hit._dedup_hide_result && (
                                     <Grid item component="span" className={classes.collection} ml={2}>
-                                        {reactIcons.fileCopy} {t('duplicate', 'Duplicate')}: [
+                                        {reactIcons.fileCopy} {t('duplicates', 'Duplicates')}: [
                                         {hit._dedup_hits.filter((x) => x !== collection).toString()}]
                                     </Grid>
                                 )}

--- a/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.styles.ts
+++ b/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.styles.ts
@@ -31,4 +31,8 @@ export const useStyles = makeStyles()((theme: Theme) => ({
         verticalAlign: 'middle',
         marginRight: theme.spacing(0.5),
     },
+
+    duplicate: {
+        opacity: 0.5,
+    },
 }))

--- a/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.tsx
+++ b/src/components/search/results/resultsTable/ResultsTableRow/ResultsTableRow.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite'
 import { cloneElement, FC } from 'react'
 
 import { reactIcons } from '../../../../../constants/icons'
+import { DEDUPLICATE_OPTIONS } from '../../../../../consts'
 import { useSharedStore } from '../../../../SharedStoreProvider'
 
 import { useResultsTableRow } from './hooks/useResultsTableRow'
@@ -12,12 +13,20 @@ import { ResultsTableRowProps } from './ResultsTableRow.types'
 export const ResultsTableRow: FC<ResultsTableRowProps> = observer(({ hit, index }) => {
     const { classes, cx } = useStyles()
     const {
+        query,
         searchViewStore: { resultsColumns },
     } = useSharedStore().searchStore
     const { formatField, start, nodeRef, isPreview, url, downloadUrl, handleResultClick } = useResultsTableRow(hit)
 
     return (
-        <TableRow data-testid="results-table-row" ref={nodeRef} onClick={handleResultClick} className={cx({ [classes.selected]: isPreview })}>
+        <TableRow
+            data-testid="results-table-row"
+            ref={nodeRef}
+            onClick={handleResultClick}
+            className={cx({
+                [classes.selected]: isPreview,
+                [classes.duplicate]: query?.dedup_results === DEDUPLICATE_OPTIONS.mark && hit._dedup_hide_result,
+            })}>
             <TableCell>{start + index}</TableCell>
             {resultsColumns.map(([field, { align, path, format }]) => (
                 <TableCell key={field} align={align}>

--- a/src/constants/icons.tsx
+++ b/src/constants/icons.tsx
@@ -76,6 +76,7 @@ import {
     ZoomIn,
     ZoomOut,
     AccountCircle,
+    FileCopy,
 } from '@mui/icons-material'
 import { createElement, CSSProperties, ReactElement } from 'react'
 
@@ -145,6 +146,7 @@ export const reactIcons: Record<string, ReactElement> = {
     zoomOut: <ZoomOut />,
     fullscreen: <Fullscreen />,
     fullscreenExit: <FullscreenExit />,
+    fileCopy: <FileCopy />,
     print: <Print />,
     contentTab: <Toc />,
     tagsTab: <LocalOfferOutlined />,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,8 @@
+export const DEDUPLICATE_OPTIONS = {
+    // default value, show all results without sending deduplication search query parameter
+    show: 0,
+    // send deduplication search query parameter and hide duplicates
+    hide: 1,
+    // send deduplication search query parameter and mark duplicates with styling and icon
+    mark: 2,
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -266,5 +266,5 @@
   "zoom_in" : "Vergrößern",
   "zoom_out" : "Verkleinern",
   "dedup_results" : "Ergebnisse deduplizieren",
-  "duplicate": "Duplikat"
+  "duplicates": "Duplikate"
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -264,5 +264,7 @@
   "year" : "Jahr",
   "years" : "Jahre",
   "zoom_in" : "Vergrößern",
-  "zoom_out" : "Verkleinern"
+  "zoom_out" : "Verkleinern",
+  "dedup_results" : "Ergebnisse deduplizieren",
+  "duplicate": "Duplikat"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -266,5 +266,5 @@
   "zoom_in" : "Zoom in",
   "zoom_out" : "Zoom out",
   "dedup_results" : "Deduplicate results",
-  "duplicate" : "Duplicate"
+  "duplicates" : "Duplicates"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -264,5 +264,7 @@
   "year" : "Year",
   "years" : "Years",
   "zoom_in" : "Zoom in",
-  "zoom_out" : "Zoom out"
+  "zoom_out" : "Zoom out",
+  "dedup_results" : "Deduplicate results",
+  "duplicate" : "Duplicate"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -266,5 +266,5 @@
   "zoom_in" : "Zoomer",
   "zoom_out" : "Dézoomer",
   "dedup_results" : "Résultats de déduplication",
-  "duplicate" : "Dupliquer"
+  "duplicates" : "Doublons"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -264,5 +264,7 @@
   "year" : "Année",
   "years" : "Années",
   "zoom_in" : "Zoomer",
-  "zoom_out" : "Dézoomer"
+  "zoom_out" : "Dézoomer",
+  "dedup_results" : "Résultats de déduplication",
+  "duplicate" : "Dupliquer"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -264,5 +264,7 @@
   "year" : "Rok",
   "years" : "Lata",
   "zoom_in" : "Powiększ",
-  "zoom_out" : "Pomniejsz"
+  "zoom_out" : "Pomniejsz",
+  "dedup_results" : "Deduplikuj wyniki",
+  "duplicate" : "duplikować"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -266,5 +266,5 @@
   "zoom_in" : "Powiększ",
   "zoom_out" : "Pomniejsz",
   "dedup_results" : "Deduplikuj wyniki",
-  "duplicate" : "duplikować"
+  "duplicate" : "Duplikaty"
 }

--- a/src/stores/HashStateStore.ts
+++ b/src/stores/HashStateStore.ts
@@ -20,6 +20,7 @@ export interface HashState {
     findIndex?: string
     date?: boolean
     collections?: string
+    dedup_results?: number
 }
 
 export class HashStateStore {

--- a/src/stores/search/SearchViewStore.ts
+++ b/src/stores/search/SearchViewStore.ts
@@ -3,6 +3,7 @@ import { ChangeEvent, ReactNode, RefObject } from 'react'
 import { Entry } from 'type-fest'
 
 import { availableColumns } from '../../constants/availableColumns'
+import { DEDUPLICATE_OPTIONS } from '../../consts'
 import { Category } from '../../Types'
 import { SharedStore } from '../SharedStore'
 
@@ -156,6 +157,19 @@ export class SearchViewStore {
         }
 
         this.searchStore.search()
+    }
+
+    handleDeduplicateResults = () => {
+        const { query, search } = this.searchStore
+
+        search({
+            dedup_results:
+                typeof query?.dedup_results === 'undefined'
+                    ? DEDUPLICATE_OPTIONS.hide
+                    : query?.dedup_results === DEDUPLICATE_OPTIONS.mark
+                      ? DEDUPLICATE_OPTIONS.show
+                      : query?.dedup_results + 1,
+        })
     }
 
     handleAllSearchCollectionsToggle = () => {

--- a/src/utils/fixLegacyQuery.ts
+++ b/src/utils/fixLegacyQuery.ts
@@ -46,7 +46,14 @@ export default function fixLegacyQuery(query: QueryParamsType): QueryParamsType 
     processOrder(query)
     processFields(query)
     processPrivateTags(query)
+    processDeduplicateResults(query)
     return query
+}
+
+const processDeduplicateResults = (query: QueryParamsType) => {
+    if (!query.dedup_results) return
+
+    query.dedup_results = parseInt(query.dedup_results as string)
 }
 
 function processCollections(query: QueryParamsType) {

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -29,6 +29,7 @@ const PARAMS_MAP: Record<string, string> = {
     ct: 'chunkTab',
     fq: 'findQuery',
     fi: 'findIndex',
+    ddr: 'dedup_results',
 }
 
 const LEGACY_PARAMS: Record<string, string> = {


### PR DESCRIPTION
closes https://github.com/CRJI/EIC/issues/1029

This ticket includes the integration of deduplication of files between collections. The checkbox has 3 states:
- unchecked - nothing happens
- checked - we _**hide**_ the duplicated results
- checked(intermediate) -  we _**mark**_ the duplicated results (opacity 0.5 and icon plus text informing which collections is it duplicated in)
